### PR TITLE
adding atomic write workaround for masterbranch

### DIFF
--- a/lib/prometheus_elb_target_finder/output.rb
+++ b/lib/prometheus_elb_target_finder/output.rb
@@ -5,7 +5,8 @@ module PrometheusElbTargetFinder
     end
 
     def create_file
-      File.open(file_path, "w") { |f| f.write(target_hash.to_json) }
+       File.open("#{file_path}.tmp", "w") { |f| f.write(target_hash.to_json) }
+       FileUtils.mv("#{file_path}.tmp", file_path)
     end
 
     def target_hash # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
atomic write is a requirement for this script to work with Prometheus, as the Prometheus will partially read the file while it is being written. 
